### PR TITLE
adds /verify and /logout endpoints

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,145 +3,260 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:3e93e899f8457138a891b3ccedcacf8fe9074865c848f7028e1892bdae280676"
   name = "github.com/dgrijalva/jwt-go"
   packages = ["."]
+  pruneopts = ""
   revision = "dbeaa9332f19a944acb5736b4456cfcc02140e29"
   version = "v3.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
+  digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = ""
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:a759b98c93c6dab29652eacd70cd7d0e88f02de8bc63051f787329966ec0a0ee"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = ""
   revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:1ff3509899d1357b533eefcc4be703aa4b8b690370de9bce65389aad226acf3c"
   name = "github.com/gorilla/securecookie"
   packages = ["."]
+  pruneopts = ""
   revision = "667fe4e3466a040b780561fe9b51a83a3753eefc"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:bfb5530b06be15a20de32e6c946eddc2d81693980c79205bcda3bd37fe1a931c"
   name = "github.com/gorilla/sessions"
   packages = ["."]
+  pruneopts = ""
   revision = "ca9ada44574153444b00d3fd9c8559e4cc95f896"
   version = "v1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:40944f9b88767f2abbe8625b5b3407cbfef9110ed29d01e8d2150e895d30f50e"
   name = "github.com/heptiolabs/healthcheck"
   packages = ["."]
+  pruneopts = ""
   revision = "9926c14869d196ae77eec009e7f016f532a5f4b9"
 
 [[projects]]
   branch = "master"
+  digest = "1:00b90d6d19c98a3a3d778a90cae1426d911887009f3817e94f6d71b2a5475928"
   name = "github.com/kubeapps/common"
-  packages = ["datastore","response"]
+  packages = [
+    "datastore",
+    "response",
+  ]
+  pruneopts = ""
   revision = "3e6c4692b57bcb6f4409ed4e573230a64d60dfba"
 
 [[projects]]
+  digest = "1:4c23ced97a470b17d9ffd788310502a077b9c1f60221a85563e49696276b4147"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = ""
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e3aa5178be4fc4ae8cdb37d11c02f7490c00450a9f419e6aa84d02d3b47e90d2"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
   revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:a6a85fc81f2a06ccac3d45005523afbeee45138d781d4f3cb7ad9889d5c65aab"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs",
+  ]
+  pruneopts = ""
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
+  digest = "1:3ac248add5bb40a3c631c5334adcd09aa72d15af2768a5bc0274084ea7b2e5ba"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = ""
   revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
   version = "v1.0.3"
 
 [[projects]]
+  digest = "1:381bcbeb112a51493d9d998bbba207a529c73dbb49b3fd789e48c63fac1f192c"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = ""
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
+
+[[projects]]
   branch = "master"
+  digest = "1:90bbd225f6aaeaebdb9912c68176548900c24b795fe0841bafa7089d180dbd91"
   name = "github.com/unrolled/render"
   packages = ["."]
+  pruneopts = ""
   revision = "65450fb6b2d3595beca39f969c411db8f8d5c806"
 
 [[projects]]
+  digest = "1:b9e40449c82e4d149a786f2e4b1f687215d61dd38eddc382a4f7f21f8408a658"
   name = "github.com/urfave/negroni"
   packages = ["."]
+  pruneopts = ""
   revision = "5dbbc83f748fc3ad38585842b0aedab546d0ea1e"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:b0323ed1d9dbcf6cb065734069c777d8ab37500d0df949fdbff179ad4a03b616"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = ""
   revision = "b080dc9a8c480b08e698fb1219160d598526310f"
 
 [[projects]]
   branch = "master"
+  digest = "1:1285570ced192ee4703ca44573a4eaf19b5a0895af56f9db2210b171eefd2a41"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+  ]
+  pruneopts = ""
   revision = "c7086645de248775cbf2373cf5ca4d2fa664b8c1"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0df6dbfc8bd4903a81bc3c224edb13e87aa9c05bc8344d802687d610e152ca4"
   name = "golang.org/x/oauth2"
-  packages = [".","internal"]
+  packages = [
+    ".",
+    "internal",
+  ]
+  pruneopts = ""
   revision = "f95fa95eaa936d9d87489b15d1d18b97c1ba9c28"
 
 [[projects]]
   branch = "master"
+  digest = "1:c1e04bf790a95ba0cbc117f167514d284f6dbc8a3ea60f96a6ebeba40df23321"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows",
+  ]
+  pruneopts = ""
   revision = "a13efeb2fd213cf4be7227992aa54519af3b2ac0"
 
 [[projects]]
+  digest = "1:934fb8966f303ede63aa405e2c8d7f0a427a05ea8df335dfdc1833dd4d40756f"
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch",
+  ]
+  pruneopts = ""
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [[projects]]
   branch = "v2"
+  digest = "1:c80894778314c7fb90d94a5ab925214900e1341afeddc953cda7398b8cdcd006"
   name = "gopkg.in/mgo.v2"
-  packages = [".","bson","internal/json","internal/sasl","internal/scram"]
+  packages = [
+    ".",
+    "bson",
+    "internal/json",
+    "internal/sasl",
+    "internal/scram",
+  ]
+  pruneopts = ""
   revision = "3f83fa5005286a7fe593b055f0d7771a7dce4655"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "412cf198c42af8d5c89f7c24b0ea2ab0b438e728d67b8e3b69ec67e632a7dd65"
+  input-imports = [
+    "github.com/dgrijalva/jwt-go",
+    "github.com/gorilla/mux",
+    "github.com/gorilla/sessions",
+    "github.com/heptiolabs/healthcheck",
+    "github.com/kubeapps/common/datastore",
+    "github.com/kubeapps/common/response",
+    "github.com/sirupsen/logrus",
+    "github.com/stretchr/testify/assert",
+    "github.com/urfave/negroni",
+    "golang.org/x/oauth2",
+    "gopkg.in/mgo.v2/bson",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2/bson"
+)
+
+// Set the JWT signingKey to a test value
+func init() {
+	key := "test"
+	signingKey = &key
+}
+
+var u = &UserModel{
+	ID:    bson.NewObjectId(),
+	Name:  "Test User",
+	Email: "test@example.com",
+}
+
+var validClaims = userClaims{
+	UserModel: u,
+	StandardClaims: jwt.StandardClaims{
+		ExpiresAt: tokenExpiration().Unix(),
+		Issuer:    "test",
+	},
+}
+
+var expiredClaims = userClaims{
+	UserModel: u,
+	StandardClaims: jwt.StandardClaims{
+		ExpiresAt: time.Now().Add(-time.Hour * 2).Unix(),
+		Issuer:    "test",
+	},
+}
+
+func signedTokenFromClaims(claims userClaims, key string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, _ := token.SignedString([]byte(key))
+	return signedToken
+}
+
+func TestVerify(t *testing.T) {
+	t.Run("no cookie/session", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/verify", nil)
+		Verify(w, r)
+
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+		assert.Contains(t, w.Body.String(), "session not found")
+	})
+
+	tests := []struct {
+		name            string
+		claims          userClaims
+		signingKey      string
+		expectedStatus  int
+		containsMessage string
+	}{
+		{"valid token", validClaims, *signingKey, http.StatusOK, ""},
+		{"invalid/expired token", expiredClaims, *signingKey, http.StatusUnauthorized, "expired"},
+		{"invalid signature", expiredClaims, "invalid", http.StatusUnauthorized, "signature is invalid"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/verify", nil)
+
+			signedToken := signedTokenFromClaims(tt.claims, tt.signingKey)
+			jwtCookie := &http.Cookie{Name: "ka_auth", Value: signedToken, Path: "/", Expires: tokenExpiration(), HttpOnly: true}
+			r.AddCookie(jwtCookie)
+
+			Verify(w, r)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			assert.Contains(t, w.Body.String(), tt.containsMessage)
+		})
+	}
+}
+
+func TestLogout(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("DELETE", "/logout", nil)
+	Logout(w, r)
+
+	cookies := w.Result().Cookies()
+	assert.Len(t, cookies, 1)
+	cookie := cookies[0]
+	assert.True(t, cookie.Expires.Before(time.Now()))
+}

--- a/main.go
+++ b/main.go
@@ -66,6 +66,8 @@ func main() {
 	// Routes
 	r.Methods("GET").Path("/").HandlerFunc(InitiateOAuth)
 	r.Methods("GET").Path("/bitnami/callback").HandlerFunc(BitnamiCallback)
+	r.Methods("GET").Path("/verify").HandlerFunc(Verify)
+	r.Methods("DELETE").Path("/logout").HandlerFunc(Logout)
 
 	n := negroni.Classic()
 	n.UseHandler(r)


### PR DESCRIPTION
This adds endpoints that used to exist on the legacy Monocular API
server to handle authentication to this service.

The verify endpoint simply verifies a JWT token is valid, and is used as
a check to see if the user is signed in. The implementation has been adapted from https://github.com/helm/monocular/blob/d130146644141dea860027d920cd4fe07dbb4f3d/src/api/middleware/authgate.go#L25.

The logout endpoint clears the current session by expiring the auth
cookie. The implementation has been adapted from https://github.com/helm/monocular/blob/d130146644141dea860027d920cd4fe07dbb4f3d/src/api/handlers/auth.go#L144-L148.